### PR TITLE
Use an independent RNG to create samples

### DIFF
--- a/gsa_module/morris/sample.py
+++ b/gsa_module/morris/sample.py
@@ -33,8 +33,16 @@
 """
 import numpy as np
 
+from numpy.random import Generator, RandomState
+from typing import Optional, Union
 
-def trajectory(r: int, k: int, p: int, seed: int) -> np.ndarray:
+
+def trajectory(
+    r: int,
+    k: int,
+    p: int,
+    seed: Optional[Union[int, Generator, RandomState]] = None,
+) -> np.ndarray:
     r"""Create Morris One-at-a-time design matrix, or the trajectory design
 
     See theory section in the documentation for the references
@@ -45,11 +53,11 @@ def trajectory(r: int, k: int, p: int, seed: int) -> np.ndarray:
     :param seed: the seed number for random number generation
     :return: the trajectory design matrix of dimension r*(k+1)-by-k
     """
-    # set the seed number
-    if seed is None:
-        np.random.seed()
+    # Create a random number generator if necessary
+    if seed is None or isinstance(seed, int):
+        rng = np.random.default_rng(seed)
     else:
-        np.random.seed(seed)
+        rng = seed
 
     # Generate B matrix, a strictly lower triangular matrix of 1
     # See [1] for the properties of B matrix
@@ -76,18 +84,18 @@ def trajectory(r: int, k: int, p: int, seed: int) -> np.ndarray:
         x_star = np.empty([k+1, k])
         # Fill in the starting point dimension-by-dimension
         for j in range(k):
-            x_star[:, j] = np.random.choice(np.arange(p / 2) / (p - 1))
+            x_star[:, j] = rng.choice(np.arange(p / 2) / (p - 1))
 
         # Generate random permutation matrix, p_star
         # See [1] for the properties of the p_star matrix
-        permuted = np.random.permutation(k)
+        permuted = rng.permutation(k)
         p_star = np.zeros([k, k])
         for j in range(k):
             p_star[j, permuted[j]] = 1
 
         # Generate random direction matrix, D_star
         # See [1] for the properties of the D_star matrix
-        d_star = np.diag([np.random.choice([-1, 1]) for _ in range(k)])
+        d_star = np.diag([rng.choice([-1, 1]) for _ in range(k)])
 
         # Set indices that signify a trajectory in the matrix
         index_list = np.arange(k+1) + i * (k+1)

--- a/gsa_module/samples/lhs.py
+++ b/gsa_module/samples/lhs.py
@@ -3,10 +3,15 @@
 """
 import numpy as np
 
-__author__ = "Damar Wicaksono"
+from numpy.random import Generator, RandomState
+from typing import Optional, Union
 
 
-def create(n: int, d: int, seed: int) -> np.ndarray:
+def create(
+    n: int,
+    d: int,
+    seed: Optional[Union[int, Generator, RandomState]],
+) -> np.ndarray:
     """Generate `n` samples of `d` dimension design matrix
 
     The function returns a numpy array of n-row and d-dimension filled with
@@ -27,17 +32,19 @@ def create(n: int, d: int, seed: int) -> np.ndarray:
     :returns: (ndarray) a numpy array of `n`-by-`d` filled with randomly
         generated random numbers of uniform variate in LHS class
     """
-    if seed is not None:
-        np.random.seed(seed)
+    if seed is None or isinstance(seed, int):
+        rng = np.random.default_rng(seed)
+    else:
+        rng = seed
 
     dm = np.empty([n, d])
 
     for j in range(d):
         for i in range(n):
-            dm[i, j] = np.random.uniform(low=i/n, high=(i+1)/n)
+            dm[i, j] = rng.uniform(low=i/n, high=(i+1)/n)
 
         if j > 0:
             # Shuffle only the d-1 dimension
-            np.random.shuffle(dm[:, j])
+            rng.shuffle(dm[:, j])
 
     return dm

--- a/gsa_module/samples/lhs_opt.py
+++ b/gsa_module/samples/lhs_opt.py
@@ -5,16 +5,22 @@ Latin Hypercube design
 import numpy as np
 from . import lhs
 
-__author__ = "Damar Wicaksono"
+from numpy.random import Generator, RandomState
+from typing import Optional, Union
 
 
-def create_ese(n: int, d: int, seed: int, max_outer: int,
-               obj_function: str="w2_discrepancy",
-               threshold_init: float=0,
-               num_exchanges: int=0,
-               max_inner: int = 0,
-               improving_params: list = [0.1, 0.8],
-               exploring_params: list = [0.1, 0.8, 0.9, 0.7]) -> np.ndarray:
+def create_ese(
+    n: int,
+    d: int,
+    seed: Optional[Union[int, Generator, RandomState]] = None,
+    max_outer: int = 1,
+    obj_function: str="w2_discrepancy",
+    threshold_init: float=0,
+    num_exchanges: int=0,
+    max_inner: int = 0,
+    improving_params: list = [0.1, 0.8],
+    exploring_params: list = [0.1, 0.8, 0.9, 0.7],
+) -> np.ndarray:
     """Generate an optimized LHS using Enhanced Stochastic Evolutionary Alg.
 
     The default parameters of the optimization can be overridden, if necessary.

--- a/gsa_module/samples/sobol.py
+++ b/gsa_module/samples/sobol.py
@@ -59,7 +59,8 @@ included direction number files in "./dirnumfiles/new-joe-kuo-6.21201"::
 """
 import numpy as np
 
-__author__ = "Damar Wicaksono"
+from numpy.random import Generator, RandomState
+from typing import Union, Optional
 
 
 def read_dirnumfile(dirnumfile: str, d: int) -> np.ndarray:
@@ -118,11 +119,14 @@ def read_dirnumfile(dirnumfile: str, d: int) -> np.ndarray:
     return dirnum
 
 
-def create(n: int, d: int,
-           dirnum: np.ndarray = None,
-           excl_nom: bool = False,
-           randomize: bool = False,
-           seed: int = None) -> np.ndarray:
+def create(
+    n: int,
+    d: int,
+    dirnum: np.ndarray = None,
+    excl_nom: bool = False,
+    randomize: bool = False,
+    seed: Optional[Union[int, Generator, RandomState]] = None,
+) -> np.ndarray:
     r"""Sobol points generator based on graycode order
 
     This implementation is a verbatim copy of a C++ source code by Joe and Kuo.
@@ -234,7 +238,10 @@ def create(n: int, d: int,
     return POINTS
 
 
-def random_shift(dm: np.ndarray, seed: int) -> np.ndarray:
+def random_shift(
+    dm: np.ndarray,
+    seed: Optional[Union[int, Generator, RandomState]] = None,
+) -> np.ndarray:
     """Randomize a given Sobol' design by random shifting
 
     Randomization of the quasi-MC samples can be achieved in the easiest manner by
@@ -250,11 +257,13 @@ def random_shift(dm: np.ndarray, seed: int) -> np.ndarray:
     :param seed: seed number for randomization
     :returns: Randomized Sobol' design matrix
     """
-    if seed is not None:
-        np.random.seed(seed)
+    if seed is None or isinstance(seed, int):
+        rng = np.random.default_rng(seed)
+    else:
+        rng = seed
 
     # Generate random shift matrix from uniform distribution
-    shift = np.repeat(np.random.rand(1, dm.shape[1]), dm.shape[0], axis=0)
+    shift = np.repeat(rng.random((1, dm.shape[1])), dm.shape[0], axis=0)
 
     # Return the shifted Sobol' design
     return (dm + shift) % 1

--- a/gsa_module/samples/srs.py
+++ b/gsa_module/samples/srs.py
@@ -3,22 +3,42 @@
 """
 import numpy as np
 
+from typing import Union, Optional
+from numpy.random import Generator, RandomState
+
 __author__ = "Damar Wicaksono"
 
 
-def create(n: int, d: int, seed: int) -> np.ndarray:
+def create(
+    n: int,
+    d: int,
+    seed: Optional[Union[int, Generator, RandomState]],
+) -> np.ndarray:
     r"""Generate `n` samples of `d` dimension using Simple Random Sampling
 
     The function returns a numpy array of `n`-rows and `d`-dimension filled
     with randomly generated number from uniform variate of [0, 1].
 
-    :param n: (int) the number of samples
-    :param d: (int) the number of dimension
-    :param seed: (int) the random seed number
-    :returns: (np.ndarray) a numpy array of `n`-by-`d` filled with randomly
-        generated random numbers of uniform variate
-    """
-    if seed is not None:
-        np.random.seed(seed)
+    Parameters
+    ----------
+    n : int
+        The number of sample points (i.e., the sample size).
+    d : int
+        The number of dimension of the input space.
+    seed : Optional[Union[int, Generator, RandomState]]
+        The seed or the random number generator object.
 
-    return np.random.rand(n, d)
+    Returns
+    -------
+    np.ndarray
+        A numpy array of `n`-by-`d` filled with randomly generated random
+        numbers of uniform variate
+    """
+    if seed is None:
+        rng = np.random.default_rng()
+    elif isinstance(seed, int):
+        rng = np.random.default_rng(seed)
+    else:
+        rng = seed
+
+    return rng.random((n, d))

--- a/gsa_module/sobol/sobol_saltelli.py
+++ b/gsa_module/sobol/sobol_saltelli.py
@@ -9,16 +9,21 @@
     to compute the Monte Carlo estimates of the Sobol' indices
 """
 import numpy as np
+
+from numpy.random import Generator, RandomState
+from typing import Union, Optional
+
 from ..samples import srs, lhs, sobol
 
-__author__ = "Damar Wicaksono"
 
-
-def create(num_samples: int, num_dimensions: int,
-           sampling_scheme: str="srs",
-           seed_number: int=None,
-           dirnum: np.ndarray=None,
-           interaction: bool=False):
+def create(
+    num_samples: int,
+    num_dimensions: int,
+    sampling_scheme: str="srs",
+    seed_number: Optional[Union[int, Generator, RandomState]]=None,
+    dirnum: np.ndarray=None,
+    interaction: bool=False,
+):
     r"""Generate Sobol'-Saltelli design matrices
 
     Sobol'-Saltelli design matrices are used to calculate the Sobol' 
@@ -57,8 +62,10 @@ def create(num_samples: int, num_dimensions: int,
         # Exclude the first two rows because each has the same values
         ab = sobol.create(n+2, 2*d, dirnum)
         ab = ab[2:]
-    else:
+    elif sampling_scheme == "srs":
         ab = srs.create(n, 2*d, seed_number)
+    else:
+        raise ValueError(f"scheme {sampling_scheme} is not supported!)")
 
     a = ab[:,:d]
     b = ab[:,d:]


### PR DESCRIPTION
Instead of using an RNG that relies on the global
state, each routines that requires an RNG
may accept an NumPy RNG.

This commit should resolve Issue #2.